### PR TITLE
Web page translate origin overlay on top

### DIFF
--- a/src/public/web-page-translate/index.ts
+++ b/src/public/web-page-translate/index.ts
@@ -396,6 +396,7 @@ const onWindowMouseMove = (e: MouseEvent) => {
                     panelElement.style.position = 'fixed';
                     panelElement.style.width = '400px';
                     panelElement.style.boxShadow = 'rgb(0 0 0 / 20%) 0px 0px 15px';
+                    panelElement.style.zIndex = '999';
                     panelElement.addEventListener('mousemove', (e: MouseEvent) => {
                         clearAllTimeout();
                         e.stopPropagation();


### PR DESCRIPTION
## What this fixes

When translating a web page and showing the original text on hover, the `#sc-webpage-translation-panel` hides behin elements with a `z-index`> 0